### PR TITLE
#160368951 Add route to get a specific order

### DIFF
--- a/server/controls/orderControl.js
+++ b/server/controls/orderControl.js
@@ -38,12 +38,33 @@ class orderControl {
                 quantity: qty2
             };
             orders.push(order);
-            resp.send(order);
+            resp.send({
+                status: 'success',
+                message: 'New order inserted',
+                order: order
+            });
         }
     }
 
     static getAllOrders(req,resp) {
-        resp.send(orders);
+        resp.send({
+            status: 'success',
+            message: 'Returning all orders',
+            orders: orders
+        });
+    }
+
+    static getOneOrder(req,resp) {
+        const order = orders.find(c => c.id === parseInt(req.params.id));
+        if (!order) resp.status(404).send({
+            status: 'error',
+            message: 'This order was not found on the list'
+        });
+        resp.send({
+            status: 'success',
+            message: 'Returning 1 order',
+            order: order
+        });
     }
 }
 

--- a/server/routes/route.js
+++ b/server/routes/route.js
@@ -5,6 +5,8 @@ const Route = (app) => {
     app.get('/api/v1/orders', orderControl.getAllOrders);
 
     app.post('/api/v1/orders', orderControl.placeOrder);
+
+    app.get('/api/v1/orders/:id', orderControl.getOneOrder);
 }
 
 export default Route;


### PR DESCRIPTION
#### What does this PR do?
- This PR integrates an api route to get a specific order on the platform
#### Description of Task to be completed?
- When a **GET** request is sent to **localhost:6060/api/v1/orders/:id**, an object is returned containing order details based on the id passed
- A successful request should return a status of 200
#### How should this be manually tested?
- Pull this branch **ft-add-route-fetch-specific-160368951** off this repository
- On your command line, run npm install to install all dependencies for this app
- On your command line, run npm start to start the app
- App would run on port **6060**
- Access the endpoint with a **GET** request on **localhost:6060/api/v1/orders/:id**
#### Any background context you want to provide?
- This app is a **node app** and would require **nodejs** and **npm** installation on your local machine
#### What are the relevant pivotal tracker stories?
[160368951](https://www.pivotaltracker.com/story/show/160368951)
#### Screenshots (if appropriate)
None
#### Questions:
None