### PR TITLE
#160848844 Get a specific menu

### DIFF
--- a/server/controllers/menuControl.js
+++ b/server/controllers/menuControl.js
@@ -53,6 +53,31 @@ class MenuControl {
             }
         )
     }
+
+    static getOneMenu(req,resp) {
+        db.query(
+            MenuQuery.getOneMenuIDQuery(req.params.id),
+            (err, res) => {
+                const [menu] = res.rows;
+                if (menu=="" || menu==null) {
+                    return resp.status(404).send({
+                        status: 'error',
+                        message: 'Menu Not Found'
+                    })
+                }
+                return resp.status(200).send({
+                    status: 'success',
+                    message: 'Returned one menu',
+                    menu: {
+                        id: menu.id,
+                        title: menu.title,
+                        price: menu.price,
+                        quantity: menu.quantity
+                    }
+                })
+            }
+        )
+    }
 }
 
 export default MenuControl;

--- a/server/controllers/menuControl.js
+++ b/server/controllers/menuControl.js
@@ -68,12 +68,7 @@ class MenuControl {
                 return resp.status(200).send({
                     status: 'success',
                     message: 'Returned one menu',
-                    menu: {
-                        id: menu.id,
-                        title: menu.title,
-                        price: menu.price,
-                        quantity: menu.quantity
-                    }
+                    menu: menu
                 })
             }
         )

--- a/server/helpers/middleware.js
+++ b/server/helpers/middleware.js
@@ -50,6 +50,18 @@ class Middleware {
         next();
     }
 
+    static validateGetOneMenu (req,resp,next) {
+        const menu = req.params.id;
+        if (isNaN(menu)) {
+            return resp.status(400).send({
+                status: 'error',
+                message: 'ID parameter must be a number'
+            });
+        }
+
+        next();
+    }
+
     static validateUpdateOrderStatus (req,resp,next) {
         const status = req.body.status;
         const statusArray = ['new','processing','cancelled','complete'];

--- a/server/queries/menuQuery.js
+++ b/server/queries/menuQuery.js
@@ -18,10 +18,18 @@ class MenuQuery {
             text: `SELECT * FROM menu WHERE quantity > 0`
         }
     }
+
     static getOneMenuQuery(title) {
         return {
             text: `SELECT * FROM menu WHERE title = $1 AND quantity > 0`,
             values: [title]
+        }
+    }
+
+    static getOneMenuIDQuery(id) {
+        return {
+            text: `SELECT * FROM menu WHERE id = $1 AND quantity > 0`,
+            values: [id]
         }
     }
 

--- a/server/queries/menuQuery.js
+++ b/server/queries/menuQuery.js
@@ -28,7 +28,7 @@ class MenuQuery {
 
     static getOneMenuIDQuery(id) {
         return {
-            text: `SELECT * FROM menu WHERE id = $1 AND quantity > 0`,
+            text: `SELECT id,title,price,quantity FROM menu WHERE id = $1 AND quantity > 0`,
             values: [id]
         }
     }

--- a/server/routes/route.js
+++ b/server/routes/route.js
@@ -81,6 +81,11 @@ const Route = (app) => {
     app.get('/api/v1/menu',
         MenuControl.getAllMenu
     )
+
+    app.get('/api/v1/menu/:id',
+        Middleware.validateGetOneMenu,
+        MenuControl.getOneMenu
+    )
 }
 
 export default Route;

--- a/server/test/menuSpec.js
+++ b/server/test/menuSpec.js
@@ -270,3 +270,35 @@ describe('/GET /api/v1/menu', () => {
         })
     })
 })
+
+describe('/GET /api/v1/menu/:id', () => {
+    it('it should get one menu', (done) => {
+    request(server)
+        .get('/api/v1/menu/1')
+        .end((err,res) => {
+            res.should.have.status(200);
+            res.body.should.be.a('object');
+            done();
+        })
+    })
+
+    it('it should return a 400 error if id parameter is not a number', (done) => {
+    request(server)
+        .get('/api/v1/menu/aaa')
+        .end((err,res) => {
+            res.should.have.status(400);
+            res.body.should.be.a('object');
+            done();
+        })
+    })
+
+    it('it should return a 404 error if menu is not found', (done) => {
+    request(server)
+        .get('/api/v1/menu/10')
+        .end((err,res) => {
+            res.should.have.status(404);
+            res.body.should.be.a('object');
+            done();
+        })
+    })
+})


### PR DESCRIPTION
#### What does this PR do?
- This PR allows users to view all available menu on the app
#### Description of Task to be completed?
- When a **GET** request is sent to **localhost:6060/api/v1/menu/:id**, user should get a response of the available menu on the app
- A successful request should return a status of 200
#### How should this be manually tested?
- Pull this branch **ft-user-able-get-specific-menu-160848844** off this repository
- On your command line, run npm install to install all dependencies for this app
- On your command line, run npm start to start the app
- App would run on port **6060**
- Access the endpoint with a **GET** request on **localhost:6060/api/v1/menu/:id**
#### Any background context you want to provide?
- This app is a **node app** and would require **nodejs** and **npm** installation on your local machine
#### What are the relevant pivotal tracker stories?
[160848844](https://www.pivotaltracker.com/story/show/160848844)
#### Screenshots (if appropriate)
![Response Object](https://user-images.githubusercontent.com/42177767/46210482-bfdf7100-c328-11e8-880f-174ca0dba4b1.PNG)

#### Questions:
None